### PR TITLE
Add agent pipeline

### DIFF
--- a/codex/agent-pipeline.yaml
+++ b/codex/agent-pipeline.yaml
@@ -1,0 +1,12 @@
+trigger:
+  event: manual
+  inputs:
+    query: string
+
+steps:
+  - task: embed_query
+    file: vectro_test.py
+  - task: query_similarity
+    file: vectro_test.py
+  - task: emit_results
+    file: vectro_test.py


### PR DESCRIPTION
## Summary
- create an agent pipeline for querying embeddings
- support embed_query, query_similarity and emit_results tasks in `vectro_test.py`

## Testing
- `python -m py_compile vectro_test.py`

------
https://chatgpt.com/codex/tasks/task_b_68651c1e5f008329a4fdb285c8ea3923